### PR TITLE
split URL to node/browser versions and add brower mapping to package.json

### DIFF
--- a/sdk/iot/modelsrepository/package.json
+++ b/sdk/iot/modelsrepository/package.json
@@ -7,7 +7,8 @@
   "module": "dist-esm/src/index.js",
   "browser": {
     "stream": "./node_modules/stream-browserify/index.js",
-    "./dist-esm/src/print.js": "./dist-esm/src/print.browser.js"
+    "./dist-esm/src/print.js": "./dist-esm/src/print.browser.js",
+    "./dist-esm/src/utils/url.js": "./dist-esm/src/utils/url.browser.js"
   },
   "types": "types/iot-models-repository.d.ts",
   "scripts": {

--- a/sdk/iot/modelsrepository/src/utils/url.browser.ts
+++ b/sdk/iot/modelsrepository/src/utils/url.browser.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+const url = URL;
+
+export { url as URL };

--- a/sdk/iot/modelsrepository/src/utils/url.ts
+++ b/sdk/iot/modelsrepository/src/utils/url.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { URL } from "url";


### PR DESCRIPTION
This PR shows how get around some of the bundling issues. Since browsers don't have access to the node.js modules, what we end up doing to keep bundlers happy is create runtime-specific versions of the APIs we need.

This looks at URL specifically. We're lucky in that both node.js and browsers support a URL parser with the same API, but in browsers we access the API via a global. So what I've done is created `utils/url.ts` and `utils/url.browser.ts` that both just re-export the URL object. Then in `package.json`, I added a mapping in the `browser` field so bundlers know that if they are targetting a browser, they should pull in the browser version of `url` instead of the node.js version.

You may need to do this for other APIs too, but this at least gets the karma tests starting to run versus just throwing a TypeError.